### PR TITLE
Refactor Repository for AWS EB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.DS_Store
+.elasticbeanstalk
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-node_modules
-dist
-.DS_Store
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -6856,6 +6856,15 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:frontend": "webpack",
     "build": "npm run build:backend && npm run build:frontend",
     "watch": "webpack --watch",
-    "start": "node ./dist/main.js"
+    "start": "npm run build && node ./dist/main.js"
   },
   "repository": {
     "type": "git",
@@ -46,7 +46,8 @@
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9",
     "webpack-dev-middleware": "^3.7.2",
-    "webpack-hot-middleware": "^2.25.0"
+    "webpack-hot-middleware": "^2.25.0",
+    "webpack-merge": "^4.2.2"
   },
   "dependencies": {
     "@material-ui/core": "^4.5.0",

--- a/src/web/web.ts
+++ b/src/web/web.ts
@@ -5,7 +5,7 @@ import webpack from "webpack";
 import webpackDevMiddleware from "webpack-dev-middleware";
 import webpackHotMiddleware from "webpack-hot-middleware";
 
-const config = require("../../webpack.config.js");
+const config = require("../../webpack.dev.js");
 
 // Express app initialization
 const app = express();

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,10 +1,8 @@
-var webpack = require("webpack");
-var hotMiddlewareScript =
+const webpack = require("webpack");
+const hotMiddlewareScript =
   "webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&reload=true";
 
 module.exports = {
-  mode: "development",
-
   entry: {
     main: ["./src/web/frontend/main.tsx", hotMiddlewareScript]
   },
@@ -15,9 +13,6 @@ module.exports = {
     path: __dirname + "/dist/web/frontend",
     publicPath: "/assets/"
   },
-
-  // Enable sourcemaps for debugging webpack's output.
-  devtool: "source-map",
 
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,9 @@
+const merge = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+  mode: "development",
+
+  // Enable sourcemaps for debugging webpack's output.
+  devtool: "source-map"
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,6 @@
+const merge = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+  mode: "production"
+});


### PR DESCRIPTION
We're going to be refactoring this repository to work with AWS Elastic Beanstalk. Netlify doesn't support webpack deployment, so it's better to use AWS EB instead because it also spins up different services to help us monitor this website.